### PR TITLE
Update in place, through Sparkle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,7 @@ jobs:
           } > notes.md
 
       - name: Publish
+        id: publish
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -118,3 +119,39 @@ jobs:
             --title "Pulse $VERSION" \
             --notes-file notes.md \
             $PRERELEASE
+
+      # After publishing, because the feed points at the release's own asset —
+      # committing it first would advertise a download that 404s.
+      #
+      # This is what makes updates *install themselves*. Sparkle refuses an
+      # archive that isn't signed by the private half of the key whose public
+      # half is baked into the app, so the signature written here is the whole
+      # trust story: it holds even though the app carries only an ad-hoc
+      # signature and Apple has vouched for nothing.
+      - name: Offer it to Sparkle
+        env:
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        run: |
+          if [ -z "$SPARKLE_PRIVATE_KEY" ]; then
+            echo "::error::SPARKLE_PRIVATE_KEY is not set — installed copies would never see this release."
+            exit 1
+          fi
+
+          URL="https://github.com/${{ github.repository }}/releases/download/v$VERSION/Pulse-$VERSION.zip"
+
+          # The tag was checked out detached; the feed lives on main.
+          git fetch origin main
+          git checkout -B main origin/main
+
+          Scripts/appcast.py "$VERSION" "build/Pulse-$VERSION.zip" "$URL"
+
+          if git diff --quiet -- appcast.xml; then
+            echo "Feed already offers $VERSION."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add appcast.xml
+          git commit -m "Offer $VERSION to Sparkle"
+          git push origin main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,15 +58,16 @@ hand anyone but a build folder.
 
 - **Pushing a tag is the whole release.**
   [`.github/workflows/release.yml`](.github/workflows/release.yml) builds,
-  packages and publishes; [`ci.yml`](.github/workflows/ci.yml) runs the same
-  build on every push. Both pin **`macos-26`** rather than `macos-latest`,
+  packages and publishes, then signs the archive and commits the Sparkle feed;
+  [`ci.yml`](.github/workflows/ci.yml) runs the same build on every push. The
+  release needs one secret, `SPARKLE_PRIVATE_KEY`, and fails loudly without it
+  rather than publishing a version no installed copy would ever be offered. Both pin **`macos-26`** rather than `macos-latest`,
   because `PanelSurface`'s Liquid Glass needs the macOS 26 SDK to compile at
   all even though it is behind an `#available` check — an older image cannot
   build the package, so both workflows check `xcrun --show-sdk-version` first
   and fail with that sentence instead of a hundred lines of "cannot find
   glassEffect". Warnings fail the build, for the reason at the top of this
-  file. Nothing is signed and no secrets are needed.
-  **The tag is checked against `VERSION`** and a mismatch fails the run: ship
+  file.   **The tag is checked against `VERSION`** and a mismatch fails the run: ship
   them out of step and every installed copy is told, forever, that an update is
   waiting. A tag with a suffix (`v1.1.0-beta.1`) is published as a pre-release,
   which GitHub's "latest release" excludes — and so, therefore, does the update
@@ -127,20 +128,44 @@ two copies of the app and shouldn't edit each other's settings.
 launch agent left over from a loose build still names the old binary, so at the
 next login launchd starts the old build *and* `SMAppService` starts the new one.
 
-**The update check is a notice, not an installer**
-([AppUpdate.swift](Sources/Pulse/AppUpdate.swift)). Pulse isn't signed with a
-Developer ID, and an app that downloads and swaps itself out without one is
-asking for trust macOS itself refuses to give. So it reads
-`/repos/qunqin24/Pulse/releases/latest` — which already skips drafts and
-pre-releases, making "tag it" the whole publishing step — and offers a link.
-When there is a Developer ID, **this is the piece Sparkle replaces.** Three
-things it gets right that are easy to get wrong: a **404 means no releases yet**
-and is an answer rather than a failure (a fresh repository would otherwise show
-an error forever); the comparison is component-wise, not string-wise, or 1.10.0
-sorts before 1.9.0; and it only ever reports something *newer*, so a working
-copy running ahead of the published release isn't told to downgrade itself.
-Nothing runs at all without a bundle — telling a developer their working copy is
-out of date is noise.
+**Updates install themselves, through Sparkle**
+([AppUpdate.swift](Sources/Pulse/AppUpdate.swift)). The thing that makes this
+safe without an Apple Developer ID is the **EdDSA key**: Sparkle refuses any
+archive not signed by the private half of the key whose public half is in
+`Info.plist`, whoever served it. Apple's signing and notarisation are
+*recommended* by Sparkle rather than required — that was got wrong here once,
+and the mistake cost a whole release cycle of "wait until there's a Developer
+ID". The one thing notarisation would fix, Gatekeeper blocking the **first**
+launch, is not something any updater can help with.
+
+The private key lives only in the `SPARKLE_PRIVATE_KEY` repository secret;
+`Scripts/sparkle-public-key.txt` holds the public half and is meant to be
+committed. [Scripts/appcast.py](Scripts/appcast.py) signs each release's zip
+and appends an entry to [appcast.xml](appcast.xml), which the release workflow
+commits back to `main` — **after** publishing, since the feed points at the
+release's own asset and committing first would advertise a 404. Sparkle updates
+from the **zip**, not the disk image; the image is for people, the zip is for
+the updater.
+
+Three things about the Swift side. `AppUpdate` starts nothing unless
+`SUFeedURL` is present, which is only true in a bundle — Sparkle's framework is
+in `Contents/Frameworks` and a `swift run` build has neither, so starting it
+there would log complaints about a missing feed forever. Sparkle's delegate is
+an `@objc` protocol and so cannot be main-actor-isolated, which is why
+`UpdaterRelay` sits between it and the `@Observable` model rather than
+`AppUpdate` conforming directly. And `didAbortWithError` fires for benign
+reasons too — the user closing Sparkle's window is one — so only a genuine
+failure to reach or read the feed is reported as one, on the single row that
+exists to tell the truth about that.
+
+**Embedding the framework is the fiddly part of the bundle.** SwiftPM links
+against Sparkle but has no app to put it in, so `Scripts/bundle.sh` copies it
+into `Contents/Frameworks` and adds `@executable_path/../Frameworks` to the
+executable's rpath — SwiftPM only ever pointed that at the build directory, and
+without the addition the app launches straight into a dyld failure. Signing then
+has to run inside out: Sparkle brings nested bundles of its own (XPC services
+and its updater app), and signing a container before its contents invalidates
+the container.
 
 Note the settings group that holds the *usage* refresh interval is called
 "Refresh", not "Updates". It was "Updates" until the app had updates of its own.

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "8ee662dd129accb89b42533c675198631ff4eec7250395dbe2c12bb91adc9675",
+  "pins" : [
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "ac2def288cbff5cfc7df3ffef6abdf45b72bcb0a",
+        "version" : "2.9.6"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -12,9 +12,19 @@ let package = Package(
     products: [
         .executable(name: "Pulse", targets: ["Pulse"])
     ],
+    dependencies: [
+        // In-place updates. Sparkle needs its framework embedded in the app
+        // bundle, which Scripts/bundle.sh does — a bare `swift run` build
+        // links against it but has nowhere to put it, so the updater is
+        // inert there. See AppUpdate.swift.
+        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.6.0")
+    ],
     targets: [
         .executableTarget(
             name: "Pulse",
+            dependencies: [
+                .product(name: "Sparkle", package: "Sparkle")
+            ],
             path: "Sources/Pulse",
             resources: [
                 .process("Resources")

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ gets out of the way the second you look away.
   explicitly in Settings (applies immediately).
 - An adaptive refresh interval (2–30 minutes) that backs off when nothing's
   changing, instead of polling on a fixed schedule around the clock.
+- Updates itself through Sparkle: checked daily, offered rather than forced,
+  and verified against a signing key so an update can only come from here.
 - **Real usage, not estimates.** Codex is read live from the endpoint its
   own CLI polls; Claude Code reports its official 5-hour and weekly limits
   through the status line hook Pulse registers (connect it in
@@ -149,8 +151,11 @@ Every push and pull request also runs
 build with warnings treated as failures, the localization key check, and an
 assembly of `Pulse.app` to prove the thing that ships still builds.
 
-Pulse checks `releases/latest` once a day and offers a link when there is a
-newer tag than the version it is running. It never installs anything itself.
+Installed copies update themselves. Sparkle checks once a day, offers the new
+version, and installs it on approval — the archive is verified against an EdDSA
+key baked into the app, so an update can only come from this repository's
+signing key. The workflow signs each release and commits the feed
+([appcast.xml](appcast.xml)) automatically.
 
 ## Project layout
 

--- a/Scripts/appcast.py
+++ b/Scripts/appcast.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Adds a build to appcast.xml, the feed Sparkle reads.
+
+Sparkle will not install an archive that isn't signed by the EdDSA key whose
+public half is in the app's Info.plist, so the signature written here is what
+makes updating safe without an Apple Developer ID. The private half never
+touches the repository: it lives in the SPARKLE_PRIVATE_KEY secret and reaches
+`sign_update` through the environment.
+
+Usage:
+    Scripts/appcast.py <version> <path-to-zip> <download-url>
+
+The feed is committed rather than generated from scratch each time. Re-signing
+older releases would mean downloading every archive ever published just to say
+the same thing about them again, and an entry that has been served once should
+not change afterwards.
+"""
+
+import email.utils
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+FEED = ROOT / "appcast.xml"
+
+SKELETON = """<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+    <channel>
+        <title>Pulse</title>
+        <link>https://raw.githubusercontent.com/qunqin24/Pulse/main/appcast.xml</link>
+        <description>Updates for Pulse.</description>
+        <language>en</language>
+    </channel>
+</rss>
+"""
+
+
+def sign(archive: Path) -> tuple[str, str]:
+    """The archive's EdDSA signature and length, from Sparkle's own tool."""
+    tools = list((ROOT / ".build" / "artifacts").rglob("sign_update"))
+    if not tools:
+        sys.exit("sign_update not found — run `swift build` first so Sparkle's tools are fetched.")
+
+    command = [str(tools[0])]
+    # In CI the key comes from the secret; on a developer's Mac `generate_keys`
+    # has already put it in the login keychain and the tool finds it there.
+    key = os.environ.get("SPARKLE_PRIVATE_KEY", "").strip()
+    if key:
+        command += ["-s", key]
+    command.append(str(archive))
+
+    output = subprocess.run(command, capture_output=True, text=True, check=True).stdout
+
+    # It prints the two attributes ready to paste: sparkle:edSignature="…" length="…"
+    parts = dict(
+        piece.split("=", 1) for piece in output.strip().replace('" ', '"\n').split("\n")
+    )
+    signature = parts["sparkle:edSignature"].strip('"')
+    length = parts["length"].strip('"')
+    return signature, length
+
+
+def main() -> None:
+    if len(sys.argv) != 4:
+        sys.exit(__doc__)
+
+    version, archive, url = sys.argv[1], Path(sys.argv[2]), sys.argv[3]
+    signature, length = sign(archive)
+
+    item = f"""        <item>
+            <title>{version}</title>
+            <pubDate>{email.utils.formatdate(localtime=False, usegmt=False)}</pubDate>
+            <sparkle:version>{version}</sparkle:version>
+            <sparkle:shortVersionString>{version}</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+            <link>https://github.com/qunqin24/Pulse/releases/tag/v{version}</link>
+            <sparkle:releaseNotesLink>https://github.com/qunqin24/Pulse/releases/tag/v{version}</sparkle:releaseNotesLink>
+            <enclosure url="{url}"
+                       length="{length}"
+                       type="application/octet-stream"
+                       sparkle:edSignature="{signature}" />
+        </item>
+"""
+
+    feed = FEED.read_text() if FEED.exists() else SKELETON
+
+    if f"<sparkle:version>{version}</sparkle:version>" in feed:
+        print(f"appcast.xml already carries {version} — leaving it alone.")
+        return
+
+    # Newest first, which is the order Sparkle and every feed reader expect.
+    anchor = "        <language>en</language>\n"
+    if anchor not in feed:
+        sys.exit("appcast.xml is not in the shape this expects — check it by hand.")
+
+    FEED.write_text(feed.replace(anchor, anchor + item, 1))
+    print(f"appcast.xml now offers {version} ({length} bytes)")
+
+
+if __name__ == "__main__":
+    main()

--- a/Scripts/bundle.sh
+++ b/Scripts/bundle.sh
@@ -24,6 +24,11 @@ cd "$(dirname "$0")/.."
 VERSION="$(tr -d '[:space:]' < VERSION)"
 APP="build/Pulse.app"
 BUNDLE_ID="io.github.qunqin24.Pulse"
+FEED_URL="https://raw.githubusercontent.com/qunqin24/Pulse/main/appcast.xml"
+# Public half of the EdDSA key updates are signed with. Safe to commit — it is
+# what *verifies* an update, and Sparkle refuses anything not signed by its
+# private half. See Scripts/appcast.py.
+PUBLIC_KEY="$(tr -d '[:space:]' < Scripts/sparkle-public-key.txt)"
 
 echo "Building Pulse $VERSION (universal)…"
 
@@ -49,6 +54,21 @@ cp "$BUILT/Pulse" "$APP/Contents/MacOS/Pulse"
 cp -R "$BUILT/Pulse_Pulse.bundle" "$APP/Contents/Resources/"
 cp AppIcon/AppIcon.icns "$APP/Contents/Resources/AppIcon.icns"
 
+# Sparkle has to travel inside the app. SwiftPM links the executable against
+# the framework but has no app to put it in, which is why a `swift run` build
+# cannot update itself and `AppUpdate` doesn't start the updater there.
+FRAMEWORK="$(find .build/artifacts -maxdepth 6 -type d -name 'Sparkle.framework' | head -1)"
+if [ -z "$FRAMEWORK" ]; then
+    echo "Sparkle.framework not found — run 'swift build' so SwiftPM fetches it." >&2
+    exit 1
+fi
+mkdir -p "$APP/Contents/Frameworks"
+cp -R "$FRAMEWORK" "$APP/Contents/Frameworks/"
+
+# The executable looks for it at @rpath; SwiftPM only ever pointed that at the
+# build directory, so without this the app launches into a dyld failure.
+install_name_tool -add_rpath "@executable_path/../Frameworks" "$APP/Contents/MacOS/Pulse" 2>/dev/null || true
+
 cat > "$APP/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -70,6 +90,16 @@ cat > "$APP/Contents/Info.plist" <<PLIST
     <key>LSUIElement</key><true/>
     <key>NSHighResolutionCapable</key><true/>
     <key>NSHumanReadableCopyright</key><string>github.com/qunqin24/Pulse</string>
+    <key>SUFeedURL</key><string>$FEED_URL</string>
+    <key>SUPublicEDKey</key><string>$PUBLIC_KEY</string>
+    <!-- Checked on a schedule without asking first. Sparkle would normally put
+         up a permission prompt, but Pulse is an .accessory app whose panel
+         never becomes key, so that window can open behind everything and go
+         unanswered. The toggle is in Settings instead, where it can be found. -->
+    <key>SUEnableAutomaticChecks</key><true/>
+    <!-- Downloading and installing on its own stays off: an update is offered,
+         not applied behind the user's back. -->
+    <key>SUAutomaticallyUpdate</key><false/>
 </dict>
 </plist>
 PLIST
@@ -78,6 +108,10 @@ PLIST
 # ad-hoc signature does not fix that — only a Developer ID and notarisation do
 # — but it does keep macOS from complaining about a *damaged* bundle when the
 # app is moved or the binary is touched.
+# Inside out: a nested bundle signed after its container invalidates the
+# container's signature, and Sparkle brings several of them (XPC services and
+# its own updater app).
+codesign --force --deep --sign - "$APP/Contents/Frameworks/Sparkle.framework" 2>/dev/null || true
 codesign --force --deep --sign - "$APP" 2>/dev/null || echo "  (ad-hoc signing skipped)"
 
 echo "→ $APP"

--- a/Scripts/sparkle-public-key.txt
+++ b/Scripts/sparkle-public-key.txt
@@ -1,0 +1,1 @@
+hVeXdZZa/kiU8L6v00nG4efZzAARYUV29NtE7FBdRgk=

--- a/Sources/Pulse/AppUpdate.swift
+++ b/Sources/Pulse/AppUpdate.swift
@@ -1,36 +1,40 @@
 import Foundation
 import Observation
+import Sparkle
 
-/// Whether a newer Pulse has been published.
+/// Keeping Pulse up to date, through Sparkle.
 ///
-/// A **notice, not an installer**. Pulse isn't signed with a Developer ID yet,
-/// and an app that downloads and swaps itself out without one is asking the
-/// user to trust something macOS itself refuses to vouch for. So this only
-/// ever says "there is a newer one, here it is" and leaves the download to the
-/// browser. When there is a Developer ID to sign and notarise with, this is
-/// the piece Sparkle replaces.
+/// **An EdDSA key is what makes this safe without an Apple Developer ID.**
+/// Sparkle refuses any archive not signed by the key in `Info.plist`, whoever
+/// served it — so the update path is verifiable even though the app itself
+/// carries only an ad-hoc signature. Apple's signing and notarisation are
+/// recommended by Sparkle rather than required, and the one thing they would
+/// fix — Gatekeeper blocking the *first* launch — is not something an updater
+/// can help with anyway.
 ///
-/// It reads GitHub's own idea of the latest release rather than a feed of our
-/// own: `/releases/latest` already skips drafts and pre-releases, so tagging a
-/// release is the whole publishing step.
+/// **Nothing starts unless Pulse is running from a bundle.** Sparkle needs an
+/// `Info.plist` carrying the feed URL and that public key, its framework in
+/// `Contents/Frameworks`, and a version to compare against; a `swift run`
+/// build has none of them. Started anyway it would log complaints about a
+/// missing feed forever, and telling a developer their working copy is out of
+/// date is noise.
 ///
-/// Nothing happens in a build that isn't an app bundle. A loose executable has
-/// no version to compare against — `swift run` produces one — and telling a
-/// developer their working copy is out of date is noise.
+/// Sparkle owns the schedule and the windows it puts up. What is kept here is
+/// only what the rest of the app asks about: whether a check can happen at
+/// all, whether one is running, and whether a newer version was found — which
+/// is what the menu bar shows.
 @MainActor
 @Observable
 final class AppUpdate {
     struct Release: Equatable, Sendable {
         let version: String
-        let page: URL
     }
 
-    /// Set only when the published version is actually newer than this one.
+    /// Set once Sparkle has found something newer, so the menu bar can say so.
     private(set) var newer: Release?
     private(set) var isChecking = false
-    private(set) var lastChecked: Date?
-    /// The last check couldn't reach GitHub. Worth showing, because otherwise
-    /// "no update" and "no answer" look identical.
+    /// The last check couldn't reach the feed. Worth showing, because "no
+    /// update" and "no answer" look identical otherwise.
     private(set) var didFail = false
 
     /// This build's version, or nil when it isn't running from a bundle.
@@ -38,110 +42,84 @@ final class AppUpdate {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
     }
 
-    var canCheck: Bool { current != nil }
+    var canCheck: Bool { controller != nil }
 
-    private static let endpoint = URL(string: "https://api.github.com/repos/qunqin24/Pulse/releases/latest")!
-    private static let interval: TimeInterval = 24 * 3_600
-    private static let lastCheckedKey = "update.lastChecked"
+    /// Sparkle's own daily schedule. Stored by Sparkle, not by `AppSettings`,
+    /// so it can't drift from what the updater is actually doing.
+    var checksAutomatically: Bool {
+        get { controller?.updater.automaticallyChecksForUpdates ?? false }
+        set { controller?.updater.automaticallyChecksForUpdates = newValue }
+    }
+
+    private var controller: SPUStandardUpdaterController?
+    private let relay = UpdaterRelay()
 
     init() {
-        let stored = UserDefaults.standard.double(forKey: Self.lastCheckedKey)
-        lastChecked = stored > 0 ? Date(timeIntervalSince1970: stored) : nil
+        // The feed URL is the tell: present only in a bundle built by
+        // Scripts/bundle.sh, which is also the only place the framework is.
+        guard
+            Bundle.main.bundleIdentifier != nil,
+            Bundle.main.object(forInfoDictionaryKey: "SUFeedURL") != nil
+        else { return }
+
+        relay.owner = self
+        controller = SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: relay,
+            userDriverDelegate: nil
+        )
     }
 
-    /// Once a day, which is often enough for a release and rare enough to stay
-    /// well inside GitHub's unauthenticated rate limit.
-    func checkIfDue() {
-        guard canCheck else { return }
-        if let lastChecked, Date().timeIntervalSince(lastChecked) < Self.interval { return }
-        check()
-    }
-
+    /// Asks now, and shows Sparkle's own window with whatever it finds.
     func check() {
-        guard canCheck, !isChecking else { return }
+        guard let controller else { return }
         isChecking = true
         didFail = false
-
-        Task { [current] in
-            let answer = await Self.latest()
-
-            self.isChecking = false
-            self.lastChecked = Date()
-            UserDefaults.standard.set(self.lastChecked!.timeIntervalSince1970, forKey: Self.lastCheckedKey)
-
-            switch answer {
-            case .none:
-                // Nothing published yet. That is an answer, not a failure —
-                // and it is the state a repository is in until its first
-                // release, which would otherwise show an error indefinitely.
-                self.newer = nil
-            case .failed:
-                self.didFail = true
-            case .found(let release):
-                // Only ever *newer*. A local build running ahead of the
-                // published release — the normal state while working on it —
-                // must not be told to downgrade itself.
-                self.newer = Self.isNewer(release.version, than: current ?? "0") ? release : nil
-            }
-        }
+        controller.updater.checkForUpdates()
     }
 
-    private enum Answer {
-        case found(Release)
-        /// Reached GitHub; there are no releases.
-        case none
-        case failed
+    /// Nothing to do: Sparkle runs its own schedule from the moment it starts.
+    /// Kept so the app's launch path doesn't have to know which updater is
+    /// behind this.
+    func checkIfDue() {}
+
+    fileprivate func finishCheck(found item: SUAppcastItem?) {
+        isChecking = false
+        didFail = false
+        newer = item.map { Release(version: $0.displayVersionString) }
     }
 
-    private static func latest() async -> Answer {
-        var request = URLRequest(url: endpoint)
-        request.timeoutInterval = 15
-        // GitHub refuses anonymous requests that don't identify themselves.
-        request.setValue("Pulse", forHTTPHeaderField: "User-Agent")
-        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+    fileprivate func failCheck(_ failed: Bool) {
+        isChecking = false
+        if failed { didFail = true }
+    }
+}
 
-        guard let (data, response) = try? await URLSession.shared.data(for: request) else {
-            return .failed
-        }
+/// Sparkle's delegate, kept apart from `AppUpdate` itself.
+///
+/// `SPUUpdaterDelegate` is an `@objc` protocol, so it has to be an `NSObject`
+/// and its methods cannot be main-actor-isolated. Rather than fight that on a
+/// type that is also `@Observable`, this stands between the two and hops onto
+/// the main actor — where Sparkle calls it from in any case.
+private final class UpdaterRelay: NSObject, SPUUpdaterDelegate {
+    /// Weak: the app owns the updater, not the other way round.
+    weak var owner: AppUpdate?
 
-        switch (response as? HTTPURLResponse)?.statusCode {
-        case 200: break
-        // A repository with no releases answers 404, and so does a private or
-        // renamed one. Either way there is nothing to offer.
-        case 404: return .none
-        default: return .failed
-        }
-
-        guard
-            let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let tag = root["tag_name"] as? String,
-            let page = (root["html_url"] as? String).flatMap(URL.init(string:))
-        else { return .failed }
-
-        // Tags are published as `v1.2.0`; the bundle's version is `1.2.0`.
-        return .found(Release(version: tag.hasPrefix("v") ? String(tag.dropFirst()) : tag, page: page))
+    nonisolated func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
+        MainActor.assumeIsolated { owner?.finishCheck(found: item) }
     }
 
-    /// Compares dot-separated version numbers a component at a time.
-    ///
-    /// Not a string comparison: "1.10.0" is newer than "1.9.0" and sorts
-    /// before it. Missing components count as zero, so "1.2" and "1.2.0" are
-    /// the same version rather than different ones.
-    static func isNewer(_ candidate: String, than current: String) -> Bool {
-        let left = components(of: candidate)
-        let right = components(of: current)
-
-        for index in 0..<max(left.count, right.count) {
-            let a = index < left.count ? left[index] : 0
-            let b = index < right.count ? right[index] : 0
-            if a != b { return a > b }
-        }
-        return false
+    nonisolated func updaterDidNotFindUpdate(_ updater: SPUUpdater) {
+        MainActor.assumeIsolated { owner?.finishCheck(found: nil) }
     }
 
-    private static func components(of version: String) -> [Int] {
-        version
-            .split(separator: ".")
-            .map { part in Int(part.prefix { $0.isNumber }) ?? 0 }
+    nonisolated func updater(_ updater: SPUUpdater, didAbortWithError error: any Error) {
+        // Sparkle aborts for benign reasons too — the user closing its window
+        // is one — and reporting those as "couldn't reach the feed" would be a
+        // lie on the one row that exists to tell the truth about that. Only a
+        // failure to *reach or read* the feed counts.
+        let failed = (error as NSError).domain == NSURLErrorDomain
+            || (error as NSError).code == Int(SUError.appcastError.rawValue)
+        MainActor.assumeIsolated { owner?.failCheck(failed) }
     }
 }

--- a/Sources/Pulse/PulseApp.swift
+++ b/Sources/Pulse/PulseApp.swift
@@ -65,7 +65,7 @@ private struct MenuBarContent: View {
             // manual one lives in Settings.
             if let newer = update.newer {
                 Button(String.localized("Pulse \(newer.version) is available")) {
-                    NSWorkspace.shared.open(newer.page)
+                    update.check()
                 }
 
                 Divider()

--- a/Sources/Pulse/Resources/en.lproj/Localizable.strings
+++ b/Sources/Pulse/Resources/en.lproj/Localizable.strings
@@ -160,10 +160,12 @@
 "Antigravity's language server" = "Antigravity's language server";
 "Refresh" = "Refresh";
 "Pulse %@ is available" = "Pulse %@ is available";
-"Download %@" = "Download %@";
 "Check now" = "Check now";
 "Checking…" = "Checking…";
-"Couldn't reach GitHub to check." = "Couldn't reach GitHub to check.";
 "Built from source — no update check." = "Built from source — no update check.";
 "%@ installed · %@ available" = "%@ installed · %@ available";
 "%@ · up to date" = "%@ · up to date";
+"Update to %@" = "Update to %@";
+"Check automatically" = "Check automatically";
+"Once a day. Updates are offered, never installed on their own." = "Once a day. Updates are offered, never installed on their own.";
+"Couldn't reach the update feed." = "Couldn't reach the update feed.";

--- a/Sources/Pulse/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Pulse/Resources/zh-Hans.lproj/Localizable.strings
@@ -160,10 +160,12 @@
 "Antigravity's language server" = "Antigravity 语言服务器";
 "Refresh" = "刷新";
 "Pulse %@ is available" = "Pulse %@ 可更新";
-"Download %@" = "下载 %@";
 "Check now" = "检查更新";
 "Checking…" = "正在检查…";
-"Couldn't reach GitHub to check." = "连不上 GitHub,没法检查。";
 "Built from source — no update check." = "源码构建,不检查更新。";
 "%@ installed · %@ available" = "已装 %@ · 可更新到 %@";
 "%@ · up to date" = "%@ · 已是最新";
+"Update to %@" = "更新到 %@";
+"Check automatically" = "自动检查";
+"Once a day. Updates are offered, never installed on their own." = "每天一次。只提示，不会自己装。";
+"Couldn't reach the update feed." = "连不上更新源。";

--- a/Sources/Pulse/SettingsView.swift
+++ b/Sources/Pulse/SettingsView.swift
@@ -586,17 +586,37 @@ struct SettingsView: View {
         VStack(alignment: .leading, spacing: 22) {
             SettingsGroup {
                 SettingsRow(String.localized("Version"), subtitle: updateSubtitle) {
-                    if let newer = update.newer {
-                        Button(String.localized("Download \(newer.version)")) {
-                            NSWorkspace.shared.open(newer.page)
+                    if update.canCheck {
+                        // Sparkle puts up its own window with whatever it
+                        // finds, so this is the same button either way — there
+                        // is nothing for Pulse to draw on top of it.
+                        Button(
+                            update.newer.map { String.localized("Update to \($0.version)") }
+                                ?? String.localized("Check now")
+                        ) {
+                            update.check()
                         }
-                    } else if update.canCheck {
-                        Button(String.localized("Check now")) { update.check() }
-                            .disabled(update.isChecking)
+                        .disabled(update.isChecking)
                     } else {
                         Text(Self.version)
                             .font(.system(size: 13))
                             .foregroundStyle(.secondary)
+                    }
+                }
+
+                if update.canCheck {
+                    SettingsRowDivider()
+
+                    SettingsRow(
+                        String.localized("Check automatically"),
+                        subtitle: String.localized("Once a day. Updates are offered, never installed on their own.")
+                    ) {
+                        Toggle("", isOn: Binding(
+                            get: { update.checksAutomatically },
+                            set: { update.checksAutomatically = $0 }
+                        ))
+                        .labelsHidden()
+                        .toggleStyle(.switch)
                     }
                 }
 
@@ -630,7 +650,7 @@ struct SettingsView: View {
             return .localized("\(Self.version) installed · \(newer.version) available")
         }
         if update.isChecking { return .localized("Checking…") }
-        if update.didFail { return .localized("Couldn't reach GitHub to check.") }
+        if update.didFail { return .localized("Couldn't reach the update feed.") }
         if !update.canCheck { return .localized("Built from source — no update check.") }
         return .localized("\(Self.version) · up to date")
     }


### PR DESCRIPTION
Replaces the update *notice* with an updater that installs.

**The correction that made this possible now.** I'd concluded real auto-update had to wait for a $99 Developer ID. That was wrong: [Sparkle's documentation](https://sparkle-project.org/documentation/) makes EdDSA signing of the archive **required** and Apple's code-signing/notarisation **recommended**. So updates are verifiable today — Sparkle refuses anything not signed by the key baked into `Info.plist`, whoever served it. Notarisation would only fix Gatekeeper blocking the *first* launch, which no updater can help with.

## How it fits together

- Private key: `SPARKLE_PRIVATE_KEY` secret, nowhere else. Public half in `Scripts/sparkle-public-key.txt`, which is meant to be committed — it *verifies*.
- `Scripts/appcast.py` signs the release zip and appends to `appcast.xml`; the workflow commits it to `main` **after** publishing, since the feed points at the release's own asset.
- Sparkle updates from the zip. The disk image stays the thing people install by hand.

## Verified locally

- Builds clean under strict Swift 6, no warnings.
- `Sparkle.framework` lands in `Contents/Frameworks`; `@executable_path/../Frameworks` is on the rpath; `codesign --verify --deep --strict` passes.
- The app launches and dyld resolves Sparkle from inside the bundle — checked with `DYLD_PRINT_LIBRARIES`.
- `sign_update` output parses and produces a valid feed entry.

The local `appcast.xml` is deliberately **not** committed: CI's zip differs byte-for-byte from a local one, so its signature is the only correct one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)