### PR TITLE
Sign the release archive the way Sparkle still supports

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,12 +113,23 @@ jobs:
           PRERELEASE=""
           case "$VERSION" in *-*) PRERELEASE="--prerelease";; esac
 
-          gh release create "v$VERSION" \
-            "build/Pulse-$VERSION.dmg" \
-            "build/Pulse-$VERSION.zip" \
-            --title "Pulse $VERSION" \
-            --notes-file notes.md \
-            $PRERELEASE
+          # Re-runnable. A later step failing used to mean deleting the release
+          # and the tag and starting over, which is a lot of ceremony for a
+          # typo in the step after this one.
+          if gh release view "v$VERSION" >/dev/null 2>&1; then
+            echo "Release exists — replacing its assets."
+            gh release upload "v$VERSION" \
+              "build/Pulse-$VERSION.dmg" \
+              "build/Pulse-$VERSION.zip" \
+              --clobber
+          else
+            gh release create "v$VERSION" \
+              "build/Pulse-$VERSION.dmg" \
+              "build/Pulse-$VERSION.zip" \
+              --title "Pulse $VERSION" \
+              --notes-file notes.md \
+              $PRERELEASE
+          fi
 
       # After publishing, because the feed points at the release's own asset —
       # committing it first would advertise a download that 404s.

--- a/Scripts/appcast.py
+++ b/Scripts/appcast.py
@@ -44,14 +44,30 @@ def sign(archive: Path) -> tuple[str, str]:
         sys.exit("sign_update not found — run `swift build` first so Sparkle's tools are fetched.")
 
     command = [str(tools[0])]
-    # In CI the key comes from the secret; on a developer's Mac `generate_keys`
-    # has already put it in the login keychain and the tool finds it there.
+
+    # In CI the key comes from the secret and is piped in; on a developer's Mac
+    # `generate_keys` has already put it in the login keychain and the tool
+    # finds it there on its own.
+    #
+    # Through stdin, not `-s`: that flag is deprecated and explicitly refuses
+    # newly generated keys, which is every key anyone would make today. It
+    # fails with a message you only see if stderr is not swallowed, which is
+    # the other half of why this cost a release run.
     key = os.environ.get("SPARKLE_PRIVATE_KEY", "").strip()
     if key:
-        command += ["-s", key]
+        command += ["--ed-key-file", "-"]
     command.append(str(archive))
 
-    output = subprocess.run(command, capture_output=True, text=True, check=True).stdout
+    result = subprocess.run(
+        command,
+        input=key + "\n" if key else None,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        sys.exit(f"sign_update failed ({result.returncode}):\n{result.stderr.strip()}")
+
+    output = result.stdout
 
     # It prints the two attributes ready to paste: sparkle:edSignature="…" length="…"
     parts = dict(


### PR DESCRIPTION
`sign_update -s` is deprecated and refuses newly generated keys — the documented CI route is piping the key to `--ed-key-file -`. Verified: the signature from the piped key matches the one from the keychain byte for byte.

The failure surfaced as a bare `exit status 1` because the script swallowed stderr; it now reports what the tool said.

Publishing is also re-runnable now, so a later step failing doesn't mean deleting the release and the tag to try again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)